### PR TITLE
[#73] 토스트 context api로 변경

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,19 +3,25 @@ import MainPage from './pages/MainPage/MainPage'
 import QuestionListPage from './pages/QuestionListPage/QuestionListPage'
 import IndividualFeedPage from './pages/IndividualFeedPage/IndividualFeedPage'
 import AnswerPageContainer from './pages/AnswerPage/AnswerPageContainer'
+import { ToastContextProvider } from './contexts/toastContextProvider'
+import MainLayout from './components/layouts/MainLayout'
 
 function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route index element={<MainPage />} />
-        <Route path="list" element={<QuestionListPage />} />
-        <Route path="post">
-          <Route path=":feedId" element={<IndividualFeedPage />} />
-          <Route path=":feedId/answer" element={<AnswerPageContainer />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+    <ToastContextProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route element={<MainLayout />}>
+            <Route index element={<MainPage />} />
+            <Route path="list" element={<QuestionListPage />} />
+            <Route path="post">
+              <Route path=":feedId" element={<IndividualFeedPage />} />
+              <Route path=":feedId/answer" element={<AnswerPageContainer />} />
+            </Route>
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </ToastContextProvider>
   )
 }
 

--- a/src/components/SocialShare.jsx
+++ b/src/components/SocialShare.jsx
@@ -2,9 +2,8 @@ import iconLink from '../assets/icons/ic_link.svg'
 import iconKakao from '../assets/icons/ic_kakao.svg'
 import iconFacebook from '../assets/icons/ic_facebook.svg'
 import styles from './SocialShare.module.css'
-import Toast from './Toast'
 
-function SocialShare({ onCopyLink, onShareKakao, onShareFacebook, showToast }) {
+function SocialShare({ onCopyLink, onShareKakao, onShareFacebook }) {
   return (
     <div className={styles['icon-container']}>
       <button type="button" onClick={onCopyLink}>
@@ -16,7 +15,6 @@ function SocialShare({ onCopyLink, onShareKakao, onShareFacebook, showToast }) {
       <button type="button" onClick={onShareFacebook}>
         <img src={iconFacebook} alt="페이스북 아이콘" />
       </button>
-      {showToast && <Toast>URL이 복사되었습니다</Toast>}
     </div>
   )
 }

--- a/src/components/SocialShareContainer.jsx
+++ b/src/components/SocialShareContainer.jsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import { useLocation } from 'react-router-dom'
 import SocialShare from './SocialShare'
+import { useToast } from '../contexts/toastContextProvider'
 
 const JAVASCRIPT_KEY = '56581d8bf8b211623ac7e64c0f1d5851'
 const INTEGRITY_VALUE =
@@ -8,17 +9,12 @@ const INTEGRITY_VALUE =
 const VERSION = '2.7.2'
 function SocialShareContainer() {
   const location = useLocation()
-  const [toastVisible, setToastVisible] = useState(false)
   const currentUrl = `${window.location.origin}${location.pathname}`
+  const { toast } = useToast()
 
   const handleCopyClick = () => {
     navigator.clipboard.writeText(currentUrl)
-
-    setToastVisible(true)
-
-    setTimeout(() => {
-      setToastVisible(false)
-    }, 5000)
+    toast({ status: 'default', message: 'URL이 복사되었습니다' })
   }
 
   const handleKakaoClick = () => {
@@ -125,7 +121,6 @@ function SocialShareContainer() {
       onCopyLink={handleCopyClick}
       onShareKakao={handleKakaoClick}
       onShareFacebook={handleFacebookClick}
-      showToast={toastVisible}
     />
   )
 }

--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -1,6 +1,13 @@
 import { useToast } from '../contexts/toastContextProvider'
 import styles from './Toast.module.css'
 
+export function ToastItem({ status, message }) {
+  return (
+    <div className={`shadow-1pt caption-1 ${styles.toast} ${styles[status]}`}>
+      <span>{message}</span>
+    </div>
+  )
+}
 export default function Toast() {
   const { toasts } = useToast()
 
@@ -9,11 +16,7 @@ export default function Toast() {
       {toasts.length > 0 &&
         toasts.map(({ id, status, message }) => (
           <li key={id}>
-            <div
-              className={`shadow-1pt caption-1 ${styles.toast} ${styles[status]}`}
-            >
-              <span>{message}</span>
-            </div>
+            <ToastItem status={status} message={message} />
           </li>
         ))}
     </ul>

--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -1,11 +1,21 @@
+import { useToast } from '../contexts/toastContextProvider'
 import styles from './Toast.module.css'
 
-function Toast({ children, status }) {
+export default function Toast() {
+  const { toasts } = useToast()
+
   return (
-    <div className={`shadow-1pt caption-1 ${styles.toast} ${styles[status]}`}>
-      {children}
-    </div>
+    <ul className={styles['toast-wrapper']}>
+      {toasts.length > 0 &&
+        toasts.map(({ id, status, message }) => (
+          <li key={id}>
+            <div
+              className={`shadow-1pt caption-1 ${styles.toast} ${styles[status]}`}
+            >
+              <span>{message}</span>
+            </div>
+          </li>
+        ))}
+    </ul>
   )
 }
-
-export default Toast

--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -1,7 +1,11 @@
 import styles from './Toast.module.css'
 
-function Toast({ children }) {
-  return <div className={styles.toast}>{children}</div>
+function Toast({ children, status }) {
+  return (
+    <div className={`shadow-1pt caption-1 ${styles.toast} ${styles[status]}`}>
+      {children}
+    </div>
+  )
 }
 
 export default Toast

--- a/src/components/Toast.module.css
+++ b/src/components/Toast.module.css
@@ -7,5 +7,14 @@
   color: #fff;
   border-radius: 8px;
   padding: 12px 20px;
-  box-shadow: 0px 4px 4px 0px #00000040;
+}
+
+.default {
+  background: var(--gray-60);
+}
+.error {
+  background: var(--red-50);
+}
+.success {
+  background-color: var(--blue-50);
 }

--- a/src/components/Toast.module.css
+++ b/src/components/Toast.module.css
@@ -28,6 +28,7 @@
   padding: 12px 20px;
   overflow: hidden;
   white-space: nowrap;
+  display: inline-block;
 }
 
 @keyframes fadeInOut {

--- a/src/components/Toast.module.css
+++ b/src/components/Toast.module.css
@@ -1,19 +1,79 @@
-.toast {
+.toast-wrapper {
   position: fixed;
   bottom: 60px;
   left: 50%;
   transform: translate(-50%, 0);
-  background-color: #000;
+  width: auto;
+  display: flex;
+  flex-direction: column-reverse;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+}
+
+.toast-wrapper li {
+  display: block;
+  overflow: hidden;
+  position: absolute;
+  transition: transform 0.3s;
+}
+
+.toast {
   color: #fff;
   border-radius: 8px;
+
+  bottom: 0;
+  width: auto;
+  background-color: #000;
   padding: 12px 20px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+@keyframes fadeInOut {
+  0% {
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+    top: 0;
+  }
+
+  80% {
+    opacity: 1;
+    top: 0;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.toast {
+  opacity: 0;
+  animation: fadeInOut 3s forwards;
+}
+
+.toast-wrapper li:nth-last-child(1) {
+  transform: translateY(0);
+}
+.toast-wrapper li:nth-last-child(2) {
+  transform: translateY(-50px);
+}
+.toast-wrapper li:nth-last-child(3) {
+  transform: translateY(-100px);
+}
+.toast-wrapper li:nth-last-child(4) {
+  transform: translateY(-150px);
+}
+.toast-wrapper li:nth-last-child(n + 5) {
+  transform: translateY(-200px);
 }
 
 .default {
-  background: var(--gray-60);
+  background-color: var(--gray-60);
 }
 .error {
-  background: var(--red-50);
+  background-color: var(--red-50);
 }
 .success {
   background-color: var(--blue-50);

--- a/src/components/layouts/MainLayout.jsx
+++ b/src/components/layouts/MainLayout.jsx
@@ -1,0 +1,11 @@
+import { Outlet } from 'react-router-dom'
+import Toast from '../Toast'
+
+export default function MainLayout() {
+  return (
+    <>
+      <Outlet />
+      <Toast />
+    </>
+  )
+}

--- a/src/contexts/toastContext.js
+++ b/src/contexts/toastContext.js
@@ -1,0 +1,12 @@
+import { createContext } from 'react'
+
+const INITIAL_CONTEXT_VALUE = {
+  toasts: [],
+  showToast: () => {},
+  hideToast: () => {},
+}
+
+// context 생성
+const ToastContext = createContext(INITIAL_CONTEXT_VALUE)
+
+export default ToastContext

--- a/src/contexts/toastContextProvider.jsx
+++ b/src/contexts/toastContextProvider.jsx
@@ -1,13 +1,9 @@
-import { useState, useContext, useMemo, useCallback, useEffect } from 'react'
+import { useState, useContext, useMemo, useCallback } from 'react'
 import ToastContext from './toastContext'
 import { getUniqueId } from '../modules/utils'
 
 export function ToastContextProvider({ children }) {
   const [toasts, setToasts] = useState([])
-
-  useEffect(() => {
-    console.log(toasts)
-  }, [toasts])
 
   const removeToast = useCallback((id) => {
     // 토스트 삭제
@@ -22,7 +18,6 @@ export function ToastContextProvider({ children }) {
   // 실제로 외부에서 사용할 토스트 함수
   const toast = useCallback(
     ({ message, status, id = getUniqueId() }) => {
-      console.log('toast', message, status)
       addToast({ message, status, id })
       setTimeout(() => {
         removeToast(id)

--- a/src/contexts/toastContextProvider.jsx
+++ b/src/contexts/toastContextProvider.jsx
@@ -1,0 +1,52 @@
+import { useState, useContext, useMemo, useCallback, useEffect } from 'react'
+import ToastContext from './toastContext'
+import { getUniqueId } from '../modules/utils'
+
+export function ToastContextProvider({ children }) {
+  const [toasts, setToasts] = useState([])
+
+  useEffect(() => {
+    console.log(toasts)
+  }, [toasts])
+
+  const removeToast = useCallback((id) => {
+    // 토스트 삭제
+    setToasts((prev) => prev.filter((toast) => toast.id !== id))
+  }, [])
+
+  const addToast = useCallback(({ message, status, id }) => {
+    // 토스트 추가
+    setToasts((prev) => [...prev, { message, status, id }])
+  }, [])
+
+  // 실제로 외부에서 사용할 토스트 함수
+  const toast = useCallback(
+    ({ message, status, id = getUniqueId() }) => {
+      console.log('toast', message, status)
+      addToast({ message, status, id })
+      setTimeout(() => {
+        removeToast(id)
+      }, 4000)
+    },
+    [addToast, removeToast]
+  )
+
+  const value = useMemo(
+    () => ({
+      toasts,
+      toast,
+    }),
+    [toasts, toast]
+  )
+
+  return <ToastContext.Provider value={value}>{children}</ToastContext.Provider>
+}
+
+// 컨텍스트 프로바이더 외부에서 사용하면 발생
+export function useToast() {
+  const context = useContext(ToastContext)
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider')
+  }
+  return context
+}

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -19,3 +19,14 @@ export const createLocalUserId = (userId) => {
   const newLocalUserId = userId
   localStorage.setItem('userId', newLocalUserId)
 }
+
+/**
+ * 현재 시간과 랜덤 숫자를 이용해 고유한 id를 만드는 함수
+ * @returns {number} id값
+ */
+export const getUniqueId = () => {
+  const timestamp = new Date().getTime()
+  const random = Math.floor(Math.random() * 1000)
+  const uniqueId = `${timestamp}${random}`
+  return uniqueId
+}

--- a/src/stories/Toast.stories.jsx
+++ b/src/stories/Toast.stories.jsx
@@ -1,0 +1,16 @@
+import Toast from '../components/Toast'
+
+export default {
+  title: 'Toasts',
+  argTypes: {
+    status: { control: 'radio', options: ['default', 'error', 'success'] },
+  },
+}
+
+const Template = (args) => <Toast {...args} />
+
+export const Toasts = Template.bind({})
+Toasts.args = {
+  children: 'URL이 복사되었습니다',
+  status: 'default',
+}

--- a/src/stories/Toast.stories.jsx
+++ b/src/stories/Toast.stories.jsx
@@ -1,4 +1,4 @@
-import Toast from '../components/Toast'
+import { ToastItem } from '../components/Toast'
 
 export default {
   title: 'Toasts',
@@ -7,10 +7,10 @@ export default {
   },
 }
 
-const Template = (args) => <Toast {...args} />
+const Template = (args) => <ToastItem {...args} />
 
 export const Toasts = Template.bind({})
 Toasts.args = {
-  children: 'URL이 복사되었습니다',
+  message: 'URL이 복사되었습니다',
   status: 'default',
 }


### PR DESCRIPTION
resolved: #73 

# 설명
context api로 변경
```
const { toast } = useToast()

toast({ status: 'default', message: 'URL이 복사되었습니다' })
```
status : default, error, success 세 가지 값을 갖고 있습니다.
위의 예제처럼 상황에 맞춰 사용하시면 됩니다.

테스트를 위해 social container 컴포넌트 수정했습니다.