### PR TITLE
[#125] 다른 피드 들어갔을 때 질문 목록 새로고침 되지 않는 문제 수정

### DIFF
--- a/src/pages/AnswerPage/AnswerPageContainer.jsx
+++ b/src/pages/AnswerPage/AnswerPageContainer.jsx
@@ -41,7 +41,10 @@ function AnswerPageContainer({
     if (offset === 0) {
       onLoadMore(feedId).then()
     }
-  }, [feedId, offset, onLoadMore])
+    if (feedId !== questions[0]?.feedId) {
+      onLoadNew(feedId)
+    }
+  }, [feedId, offset, onLoadMore, onLoadNew, questions])
 
   if (profile) {
     return (

--- a/src/pages/IndividualFeedPage/IndividualFeedPage.jsx
+++ b/src/pages/IndividualFeedPage/IndividualFeedPage.jsx
@@ -60,7 +60,10 @@ export default function IndividualFeedPage({
     if (offset === 0) {
       onLoadMore(feedId).then()
     }
-  }, [feedId, offset, onLoadMore])
+    if (feedId !== questions[0]?.feedId) {
+      onLoadNew(feedId)
+    }
+  }, [feedId, offset, onLoadMore, onLoadNew, questions])
 
   if (profile) {
     return (


### PR DESCRIPTION
resolved: #125 

# 설명
뒤로가기 후 다른 피드 선택했을 때 질문 목록 새로고침되도록 현재 질문의 아이디와 프로필 정보의 아이디를 비교하여 새로 로드합니다.