### PR TITLE
[#125] 다른 피드 들어갔을 때 질문 새로고침 해결

### DIFF
--- a/src/pages/AnswerPage/AnswerPageContainer.jsx
+++ b/src/pages/AnswerPage/AnswerPageContainer.jsx
@@ -42,7 +42,7 @@ function AnswerPageContainer({
 
   useEffect(() => {
     loadProfile(feedId).then()
-  }, [feedId, loadProfile, questions])
+  }, [feedId, loadProfile])
 
   useEffect(() => {
     if (isNewProfile) {

--- a/src/pages/AnswerPage/AnswerPageContainer.jsx
+++ b/src/pages/AnswerPage/AnswerPageContainer.jsx
@@ -49,6 +49,7 @@ function AnswerPageContainer({
       // 새 프로필에 들어가면 질문도 새로 로딩합니다.
       onLoadNew(feedId).then()
     }
+    // 새 프로필이 아닌 경우 질문을 새로 로딩할지 결정합니다.
     const questionSubjectId = questions[0]?.subjectId
     if (questionSubjectId === undefined) {
       // 질문 받은 아이디를 찾을 수 없는 경우 질문이 0개이므로 그만 로딩합니다.

--- a/src/pages/IndividualFeedPage/IndividualFeedPage.jsx
+++ b/src/pages/IndividualFeedPage/IndividualFeedPage.jsx
@@ -62,6 +62,7 @@ export default function IndividualFeedPage({
       // 새 프로필에 들어가면 질문도 새로 로딩합니다.
       onLoadNew(feedId).then()
     }
+    // 새 프로필이 아닌 경우 질문을 새로 로딩할지 결정합니다.
     const questionSubjectId = questions[0]?.subjectId
     if (questionSubjectId === undefined) {
       // 질문 받은 아이디를 찾을 수 없는 경우 질문이 0개이므로 그만 로딩합니다.


### PR DESCRIPTION
resolved: #125 

# 설명
전 피드가 0개일 경우 새로고침이 되지 않아서 조건문 검토했습니다

```jsx
 useEffect(() => {
    if (isNewProfile) {
      // 새 프로필에 들어가면 질문도 새로 로딩합니다.
      onLoadNew(feedId).then()
    }
    // 새 프로필이 아닌 경우 질문을 새로 로딩할지 결정합니다.
    const questionSubjectId = questions[0]?.subjectId
    if (questionSubjectId === undefined) {
      // 질문 받은 아이디를 찾을 수 없는 경우 질문이 0개이므로 그만 로딩합니다.
      return
    }
    if (feedId !== String(questionSubjectId)) {
      // 질문 받은 아이디가 주소의 아이디와 다를 경우 질문을 새로 로딩합니다.
      onLoadNew(feedId).then()
    }
  }, [feedId, onLoadMore, onLoadNew, questions, isNewProfile])
```

